### PR TITLE
Исправления для репозитория

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1051,3 +1051,5 @@ dkms.conf
 .vscode/*
 build
 build/*
+.lldbinit
+.gdbinit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG        release-1.12.0
+        GIT_TAG        6910c9d9165801d8827d628cb72eb7ea9dd538c5
 )
 FetchContent_MakeAvailable(googletest)
 

--- a/tasks/bmstu_lets/CMakeLists.txt
+++ b/tasks/bmstu_lets/CMakeLists.txt
@@ -20,3 +20,5 @@ target_link_libraries(
         ${NAME_EXECUTABLE}
         GTest::gtest_main
 )
+
+gtest_discover_tests(${NAME_EXECUTABLE})

--- a/tasks/bmstu_simple_vector/CMakeLists.txt
+++ b/tasks/bmstu_simple_vector/CMakeLists.txt
@@ -21,3 +21,5 @@ target_link_libraries(
         ${NAME_EXECUTABLE}
         GTest::gtest_main
 )
+
+gtest_discover_tests(${NAME_EXECUTABLE})

--- a/tasks/bmstu_string/CMakeLists.txt
+++ b/tasks/bmstu_string/CMakeLists.txt
@@ -21,3 +21,5 @@ target_link_libraries(
         ${NAME_EXECUTABLE}
         GTest::gtest_main
 )
+
+gtest_discover_tests(${NAME_EXECUTABLE})

--- a/tasks/task_basic_c/CMakeLists.txt
+++ b/tasks/task_basic_c/CMakeLists.txt
@@ -20,3 +20,5 @@ target_link_libraries(
         ${NAME_EXECUTABLE}
         GTest::gtest_main
 )
+
+gtest_discover_tests(${NAME_EXECUTABLE})


### PR DESCRIPTION
-Исправление: Теперь в VSCode отображаются тесты в TestExploer
-Исправление: Исправлена версия gtest, вследствие чего пропали уведомления о не поддержке cmake 3.10
-Исправление: В gitignore добавлены файлы, созданные lldbprinter и gdbprinter