### PR TITLE
Bmstu list printers

### DIFF
--- a/bmstu_list_printer_gdb.py
+++ b/bmstu_list_printer_gdb.py
@@ -1,0 +1,50 @@
+# .vscode/bmstu_list_printer.py
+import gdb
+import gdb.printing
+
+class BmstuListPrinter:
+    def __init__(self, val):
+        self.val = val
+        self.size = int(val['size_'])
+        self.head = val['head_']
+        self.tail = val['tail_']
+
+    def to_string(self):
+        return f"bmstu::list<{self.val.type.template_argument(0)}> (size={self.size})"
+
+    def children(self):
+        current_node = self.head['next_node_']
+        end_node = self.tail.address
+        
+        index = 0
+        while current_node != end_node and index < self.size:
+            try:
+                # Дереференс указателя на узел
+                node = current_node.dereference()
+                # Получаем значение
+                value = node['value_']
+                yield f"[{index}]", value
+                
+                # Переходим к следующему узлу
+                current_node = node['next_node_']
+                index += 1
+            except gdb.MemoryError:
+                yield f"[{index}]", "<memory error>"
+                break
+            except Exception as e:
+                yield f"[{index}]", f"<error: {str(e)}>"
+                break
+
+    def display_hint(self):
+        return "array"
+
+def build_pretty_printer():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("bmstu_list")
+    pp.add_printer('bmstu::list', '^bmstu::list<.*>$', BmstuListPrinter)
+    return pp
+
+gdb.printing.register_pretty_printer(
+    gdb.current_objfile(),
+    build_pretty_printer(),
+    replace=True
+)

--- a/bmstu_list_printer_lldb.py
+++ b/bmstu_list_printer_lldb.py
@@ -1,0 +1,43 @@
+import lldb
+
+def bmstu_list_summary(valobj, internal_dict):
+    try:
+        size = valobj.GetChildMemberWithName("size_").GetValueAsUnsigned(0)
+        head = valobj.GetChildMemberWithName("head_")
+        tail = valobj.GetChildMemberWithName("tail_")
+        
+        if size == 0:
+            return "bmstu::list<{}> (size=0, empty)".format(
+                valobj.GetType().GetTemplateArgumentType(0).GetName()
+            )
+     
+        elements = []
+        current = head.GetChildMemberWithName("next_node_")
+        end = tail
+        
+        index = 0
+        while current.GetValueAsUnsigned(0) != end.GetValueAsUnsigned(0) and index < 100: 
+            node = current.Dereference()
+            value = node.GetChildMemberWithName("value_")
+            
+            if value.GetType().IsPointerType():
+                value = value.Dereference()
+            
+            elements.append("[{}] = {}".format(index, value.GetValue()))
+            current = node.GetChildMemberWithName("next_node_")
+            index += 1
+        
+        return "bmstu::list<{}> (size={}, contents=[{}])".format(
+            valobj.GetType().GetTemplateArgumentType(0).GetName(),
+            size,
+            ", ".join(elements)
+        )
+    
+    except Exception as e:
+        return "bmstu::list<...> (error: {})".format(str(e))
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand(
+        'type summary add -F bmstu_list_lldb.bmstu_list_summary "bmstu::list<.*>" -w bmstu'
+    )
+    print("[LLDB] Registered pretty-printer for bmstu::list")

--- a/bmstu_list_printer_msvc.natvis
+++ b/bmstu_list_printer_msvc.natvis
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="bmstu::list&lt;*&gt;">
+    <DisplayString>{{ size = {size_} }}</DisplayString>
+    <Expand>
+      <Item Name="[size]">size_</Item>
+      <LinkedListItems>
+        <Size>size_</Size>
+        <HeadPointer>head_.next_node_</HeadPointer>
+        <NextPointer>next_node_</NextPointer>
+        <ValueNode>value_</ValueNode>
+      </LinkedListItems>
+    </Expand>
+  </Type>
+
+  <Type Name="bmstu::list&lt;*&gt;::node">
+    <DisplayString>{value_}</DisplayString>
+  </Type>
+</AutoVisualizer>


### PR DESCRIPTION
Сделаны 3 новых файла в корневой папке: два питоновских (для linux и macOS) и один natvis (для windows), при добавлении в репозиторий позволяют отображать содержимое листа корректно(размер и набор хранящихся элементов)